### PR TITLE
Add dark mode toggle

### DIFF
--- a/src/ThemeContext.js
+++ b/src/ThemeContext.js
@@ -1,0 +1,32 @@
+import React, { useState, useEffect } from 'react';
+
+const ThemeContext = React.createContext({ dark: false, toggle: () => {} });
+
+export const ThemeProvider = ({ children }) => {
+  const [dark, setDark] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return window.localStorage.getItem('dark') === 'true';
+    }
+    return false;
+  });
+
+  useEffect(() => {
+    const className = 'dark-mode';
+    if (dark) {
+      document.body.classList.add(className);
+    } else {
+      document.body.classList.remove(className);
+    }
+    window.localStorage.setItem('dark', dark);
+  }, [dark]);
+
+  const toggle = () => setDark(prev => !prev);
+
+  return (
+    <ThemeContext.Provider value={{ dark, toggle }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export default ThemeContext;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,10 +1,20 @@
 import React from 'react';
+import ThemeContext from '../ThemeContext';
 import { Link } from 'react-router-dom';
 
 const LoggedOutView = props => {
   if (!props.currentUser) {
     return (
       <ul className="nav navbar-nav pull-xs-right">
+        <ThemeContext.Consumer>
+          {({ toggle, dark }) => (
+            <li className="nav-item">
+              <button className="nav-link btn btn-link" onClick={toggle}>
+                {dark ? 'Light Mode' : 'Dark Mode'}
+              </button>
+            </li>
+          )}
+        </ThemeContext.Consumer>
 
         <li className="nav-item">
           <Link to="/" className="nav-link">
@@ -34,6 +44,15 @@ const LoggedInView = props => {
   if (props.currentUser) {
     return (
       <ul className="nav navbar-nav pull-xs-right">
+        <ThemeContext.Consumer>
+          {({ toggle, dark }) => (
+            <li className="nav-item">
+              <button className="nav-link btn btn-link" onClick={toggle}>
+                {dark ? 'Light Mode' : 'Dark Mode'}
+              </button>
+            </li>
+          )}
+        </ThemeContext.Consumer>
 
         <li className="nav-item">
           <Link to="/" className="nav-link">

--- a/src/index.js
+++ b/src/index.js
@@ -7,14 +7,18 @@ import { Route, Switch } from 'react-router-dom';
 import { ConnectedRouter } from 'react-router-redux';
 
 import App from './components/App';
+import { ThemeProvider } from './ThemeContext';
+import './theme.css';
 
 ReactDOM.render((
   <Provider store={store}>
-    <ConnectedRouter history={history}>
-      <Switch>
-        <Route path="/" component={App} />
-      </Switch>
-    </ConnectedRouter>
+    <ThemeProvider>
+      <ConnectedRouter history={history}>
+        <Switch>
+          <Route path="/" component={App} />
+        </Switch>
+      </ConnectedRouter>
+    </ThemeProvider>
   </Provider>
 
 ), document.getElementById('root'));

--- a/src/theme.css
+++ b/src/theme.css
@@ -1,0 +1,28 @@
+body.dark-mode {
+  background-color: #121212;
+  color: #ffffff;
+}
+
+body.dark-mode a {
+  color: #90caf9;
+}
+
+body.dark-mode .navbar,
+body.dark-mode .article-preview,
+body.dark-mode .pager {
+  background-color: #1f1f1f;
+}
+
+body.dark-mode .nav-link,
+body.dark-mode .navbar-brand {
+  color: #ffffff;
+}
+
+body.dark-mode .btn-outline-primary {
+  color: #90caf9;
+  border-color: #90caf9;
+}
+body.dark-mode .btn-outline-primary:hover {
+  background-color: #90caf9;
+  color: #000;
+}


### PR DESCRIPTION
## Summary
- add ThemeContext provider for dark mode
- apply dark mode styles via `theme.css`
- hook ThemeProvider into the app
- expose a dark mode toggle in the header

## Testing
- `npm test` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d1bd5fa908331ab876ea251023727